### PR TITLE
Writing Files with pyexcel

### DIFF
--- a/SSD_MobileNet_prototxt.txt
+++ b/SSD_MobileNet_prototxt.txt
@@ -101,6 +101,25 @@ layer {
   }
   
 }
+book = xlsxwriter.Book('Example2.xlsx')     
+sheet = book.add_sheet()     
+       
+# Rows and columns are zero indexed.     
+row = 0    
+column = 0    
+      
+content = ["Parker", "Smith", "John"]     
+      
+# iterating through the content list     
+for item in content :     
+      
+    # write operation perform     
+    sheet.write(row, column, item)     
+      
+    # incrementing the value of row by one with each iterations.     
+    row += 1    
+          
+book.close()     
 layer {
   name: "conv1/relu"
   type: "Relu"


### PR DESCRIPTION
You can easily export your arrays back to a spreadsheet by using the save_as() function and pass the array and name of the destination file to the dest_file_name argument.

It allows us to specify the delimiter and add dest_delimiter argument. You can pass the symbol that you want to use as a delimiter in-between " ".