### PR TITLE
Incorrect Indexing

### DIFF
--- a/social_distance_detection.py
+++ b/social_distance_detection.py
@@ -255,7 +255,7 @@ print(fibonacci(9))
             COLOR = np.array([0,0,255])
         else:
             COLOR = np.array([0,255,0])
-        (startX, startY, endX, endY, 0) = coordinates[i]
+        (startX, startY, endX, endY) = coordinates[i]
 try:
     linux_interaction()
 except AssertionError as error:


### PR DESCRIPTION
The tuple unpacking has an extra index (0), which might cause an error. Remove the , 0.